### PR TITLE
Flac to ID3 Metadata Copying

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,10 @@ setup(
     entry_points = {
         'console_scripts': [
             'flac2id3 = mutagentools.cli.flac2id3:main',
+            'flacclear = mutagentools.cli.flacclear:main',
             'flacjson = mutagentools.cli.flacjson:main',
             'id3clean = mutagentools.cli.id3clean:main',
+            'id3clear = mutagentools.cli.id3clear:main',
             'id3json = mutagentools.cli.id3json:main',
         ]
     }

--- a/src/mutagentools/cli/__init__.py
+++ b/src/mutagentools/cli/__init__.py
@@ -2,6 +2,12 @@
 # -*- coding: utf-8 -*-
 
 from mutagentools.cli import (
+    # flac tools
     flac2id3,
+    flacclear,
+    flacjson,
+    # id3 tools
     id3clean,
+    id3clear,
+    id3json,
 )

--- a/src/mutagentools/cli/flac2id3/__init__.py
+++ b/src/mutagentools/cli/flac2id3/__init__.py
@@ -1,8 +1,37 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import argparse
+
+from mutagen.flac import FLAC
+from mutagen.id3 import ID3
+from mutagen.mp3 import MP3
+
+from mutagentools.flac import convert_flac_to_id3
+
+
 def main():
-    print("SOMEPING")
+    parser = argparse.ArgumentParser(description="Copies FLAC Vorbis tags to an ID3 compliant file.")
+    parser.add_argument('-d', '--delete', action='store_true',
+        help="Delete all tags in the destination ID3 file before copying tags over.")
+    parser.add_argument('flac_file', type=argparse.FileType('r'), help="FLAC file to copy tags from.")
+    parser.add_argument('id3_file', type=argparse.FileType('r'), help="ID3 compliant file to copy tags to.")
+    args = parser.parse_args()
+
+    # open FLAC file
+    src = FLAC(args.flac_file.name)
+
+    # open MP3/ID3 file
+    dest = ID3(args.id3_file.name)
+
+    # if we are meant to clear the dest tags, clear them
+    dest.clear() if args.delete else None
+
+    # now, copy over the tags
+    list(map(lambda t: dest.add(t), convert_flac_to_id3(src)))
+
+    # save; writing ID3v1 tags and ID3v2.4 tags
+    dest.save(args.id3_file.name, 2, 4)
 
 
 if __name__ == "__main__":

--- a/src/mutagentools/cli/flacclear/__init__.py
+++ b/src/mutagentools/cli/flacclear/__init__.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+
+from mutagen.flac import FLAC
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Clear all tags from a FLAC file.")
+    parser.add_argument('-v', '--verbose', action='store_true', help="Verbose output.")
+    parser.add_argument('flac_file', type=argparse.FileType('r'), nargs='+',
+        help="FLAC file(s) to remove tags from.")
+    args = parser.parse_args()
+
+    for flac_file in args.flac_file:
+        if args.verbose:
+            print("Removing FLAC tags and pictures from {}...".format(flac_file.name))
+
+        f = FLAC(flac_file.name)
+        f.clear()
+        f.clear_pictures()
+        f.save()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mutagentools/cli/id3clear/__init__.py
+++ b/src/mutagentools/cli/id3clear/__init__.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+
+from mutagen.id3 import ID3
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Clear all ID3 tags from a file.")
+    parser.add_argument('-v', '--verbose', action='store_true', help="Verbose output.")
+    parser.add_argument('id3_file', type=argparse.FileType('r'), nargs='+',
+        help="ID3 containing file(s) to remove tags from.")
+    args = parser.parse_args()
+
+    for id3_file in args.id3_file:
+        if args.verbose:
+            print("Removing ID3 tags from {}...".format(id3_file.name))
+
+        f = ID3(id3_file.name)
+        f.clear()
+        f.save()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mutagentools/flac/__init__.py
+++ b/src/mutagentools/flac/__init__.py
@@ -5,6 +5,7 @@ from base64 import b64encode
 
 from mutagen.id3 import PictureType
 
+from mutagentools.flac.convert import convert_flac_to_id3
 from mutagentools.utils import fold_text_keys
 
 

--- a/src/mutagentools/flac/convert.py
+++ b/src/mutagentools/flac/convert.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from mutagen.id3 import (
+    APIC, ID3, MCDI, TALB, TCON, TCOM, TDRC, TIT2, TLEN, TPE1, TPE2, TPOS, TPUB, TRCK, TXXX, UFID, Encoding
+)
+
+import re
+import struct
+
+
+PART_OF_SET = re.compile(r'^(?P<number>\d+)/(?P<total>\d+)$')
+
+
+def convert_flac_to_id3(flac):
+    """Convert FLAC tags to ID3 tags."""
+    result = []
+    tags = dict(flac.tags)
+
+    # remove crc because we don't care about the original FLAC's CRC
+    tags.pop('crc') if 'crc' in tags.keys() else None
+
+    # artist related tags
+    if 'albumartist' in tags.keys() or 'album artist' in tags.keys():
+        result.append(convert_albumartist_to_tpe2(list(map(lambda k: tags.pop(k), ['albumartist', 'album artist']))[0]))
+
+    if 'artist' in tags.keys() or 'author' in tags.keys():
+        result.append(convert_artist_to_tpe1(list(map(lambda k: tags.pop(k), ['artist', 'author']))[0]))
+
+    if 'composer' in tags.keys():
+        result.append(convert_composer_to_tcom(tags.pop('composer')))
+
+    # album related tags
+    if 'album' in tags.keys():
+        result.append(convert_album_to_talb(tags.pop('album')))
+
+    if 'genre' in tags.keys():
+        result.append(convert_genre_to_tcon(tags.pop('genre'), tags.pop('style') if 'style' in tags.keys() else []))
+
+    if 'discnumber' in tags.keys():
+        result.append(convert_disc_number_to_tpos(tags.pop('discnumber'),
+            tags.pop('totaldiscs') if 'totaldiscs' in tags.keys() else None))
+
+    if 'date' in tags.keys() or 'year' in tags.keys():
+        result.append(convert_date_to_tdrc(list(map(lambda k: tags.pop(k), ['date', 'year']))[0]))
+
+    if 'organization' in tags.keys():
+        result.append(convert_organization_to_tpub(tags.pop('organization')))
+
+    if 'cdtoc' in tags.keys():
+        result.append(convert_toc_to_mcdi(tags.pop('cdtoc')))
+
+    if 'mbid' in tags.keys():
+        result.append(convert_mbid_to_ufid(tags.pop('mbid')))
+
+    # track related tags
+    if 'title' in tags.keys():
+        result.append(convert_title_to_tit2(tags.pop('title')))
+
+    if 'tracknumber' in tags.keys():
+        tracknumber = tags.pop('tracknumber')
+        totaltracks = tags.pop('totaltracks') if 'totaltracks' in tags.keys() else None
+
+        if PART_OF_SET.match(tracknumber):
+            # it's a complicated dude
+            tracknumber, totaltracks = PART_OF_SET.match(tracknumber).groups()
+
+        result.append(convert_track_number_to_trck(tracknumber, totaltracks))
+
+    if 'length' in tags.keys():
+        result.append(convert_length_to_tlen(tags.pop('length')))
+
+    # encoding tags
+    if 'encoder' in tags.keys():
+        result.append(convert_encoder_to_txxx(tags.pop('encoder')))
+
+    if 'encoded by' in tags.keys():
+        result.append(convert_encoded_by_to_txxx(tags.pop('encoded by')))
+
+    if 'encoder settings' in tags.keys():
+        result.append(convert_encoder_settings_to_txxx(tags.pop('encoder settings')))
+
+    # catch the rest in txxx
+    for tag in tags:
+        result.append(convert_generic_to_txxx(tag, tags.get(tag)))
+
+    # add the pictures
+    for picture in flac.pictures:
+        result.append(APIC(
+            encoding=Encoding.UTF8,
+            type=picture.type,
+            desc=picture.desc,
+            mime=picture.mime,
+            data=bytes(picture.data))
+        )
+
+    # if there is no disc number, add one manually
+    if not 'TPOS' in list(map(lambda t: t.FrameID, result)):
+        result.append(convert_disc_number_to_tpos('1', '1'))
+
+    return result
+
+
+def convert_generic_to_txxx(flac_key, flac_value):
+    """Converts a generic FLAC Vorbis comment into a TXXX tag."""
+    return TXXX(encoding=Encoding.UTF8, desc=flac_key, text=flac_value)
+
+
+def convert_encoder_to_txxx(flac_encoder):
+    """Converts a FLAC encoder Vorbis comment into a TXXX tag."""
+    return TXXX(encoding=Encoding.UTF8, desc="original encoder", text=flac_encoder)
+
+
+def convert_encoded_by_to_txxx(flac_encoded_by):
+    """Converts a FLAC encoded by Vorbis comment into a TXXX tag."""
+    return TXXX(encoding=Encoding.UTF8, desc="originally encoded by", text=flac_encoded_by)
+
+
+def convert_encoder_settings_to_txxx(flac_encoder_settings):
+    """Converts a FLAC encoder settings Vorbis comment into a TXXX tag."""
+    return TXXX(encoding=Encoding.UTF8, desc="original encoder settings", text=flac_encoder_settings)
+
+
+def convert_disc_number_to_tpos(flac_discnumber, flac_totaldiscs=None):
+    """Converts a FLAC disc number and optionally total discs into a TPOS tag."""
+    # unwrap
+    flac_discnumber = flac_discnumber if not isinstance(flac_discnumber, list) else flac_discnumber[0]
+
+    value = "{:01}".format(int(flac_discnumber))
+
+    if flac_totaldiscs and len(flac_totaldiscs) > 0:
+        if isinstance(flac_totaldiscs, list):
+            # unpack
+            flac_totaldiscs = flac_totaldiscs[0]
+
+        value = "{}/{:01}".format(value, int(flac_totaldiscs))
+
+    return TPOS(encoding=Encoding.UTF8, text=value)
+
+
+def convert_track_number_to_trck(flac_tracknumber, flac_totaltracks=None):
+    """Converts a FLAC track number and optionally total tracks into a TRCK tag."""
+    if isinstance(flac_tracknumber, list):
+        # unpack
+        flac_tracknumber = flac_tracknumber[0]
+
+    value = "{:02}".format(int(flac_tracknumber))
+
+    if flac_totaltracks and len(flac_totaltracks) > 0:
+        if isinstance(flac_totaltracks, list):
+            # unpack
+            flac_totaltracks = flac_totaltracks[0]
+
+        value = "{}/{:02}".format(value, int(flac_totaltracks))
+
+    return TRCK(encoding=Encoding.UTF8, text=value)
+
+
+def convert_genre_to_tcon(flac_genre, flac_style=None):
+    """Converts a FLAC genre and optionally styles into a TCON tag."""
+    # convert both to lists
+    flac_genre = flac_genre if isinstance(flac_genre, list) else [flac_genre]
+    flac_style = flac_style if isinstance(flac_style, list) else [flac_style]
+
+    # create a list of non-empty genres from the genres and styles
+    genre_list = list(filter(lambda i: i is not None, flac_genre + flac_style))
+
+    # return genres first, followed by styles
+    return TCON(encoding=Encoding.UTF8, text=genre_list)
+
+
+def convert_length_to_tlen(flac_length):
+    """Converts a FLAC length in milliseconds into a TLEN tag."""
+    if isinstance(flac_length, (set, list)):
+        flac_length = flac_length[0]
+
+    return TLEN(encoding=Encoding.UTF8, text=str(flac_length))
+
+
+def convert_mbid_to_ufid(flac_mbid):
+    """Converts a FLAC MusicBrainz ID into a UFID tag."""
+    if isinstance(flac_mbid, list):
+        # flatten that shita
+        flac_mbid = flac_mbid[0]
+
+    return UFID(owner="http://musicbrainz.org", data=flac_mbid if isinstance(flac_mbid, bytes) else bytes(flac_mbid, 'ascii'))
+
+
+def convert_album_to_talb(flac_album):
+    """Converts a FLAC album to a TALB tag."""
+    return TALB(encoding=Encoding.UTF8, text=flac_album)
+
+
+def convert_organization_to_tpub(flac_organization):
+    """Converts a FLAC organization (record label) into a TPUB tag."""
+    return TPUB(encoding=Encoding.UTF8, text=flac_organization)
+
+
+def convert_albumartist_to_tpe2(flac_albumartist):
+    """Converts a FLAC album artist into a TPE2 tag."""
+    return TPE2(encoding=Encoding.UTF8, text=flac_albumartist)
+
+
+def convert_artist_to_tpe1(flac_artist):
+    """Converts a FLAC artist into a TPE1 tag."""
+    return TPE1(encoding=Encoding.UTF8, text=flac_artist)
+
+
+def convert_title_to_tit2(flac_title):
+    """Converts a FLAC title into a TIT2 tag."""
+    return TIT2(encoding=Encoding.UTF8, text=flac_title)
+
+
+def convert_date_to_tdrc(flac_date):
+    """Converts a FLAC date into a TDRC tag."""
+    return TDRC(encoding=Encoding.UTF8, text=flac_date)
+
+
+def convert_composer_to_tcom(composer):
+    """Converts a FLAC composer tag into a TCOM."""
+    return TCOM(encoding=Encoding.UTF8, text=composer)
+
+
+def convert_picture_to_apic(flac_picture):
+    """Converts a FLAC picture into an APIC tag."""
+    return APIC(encoding=Encoding.UTF8, mime=flac_picture.mime, type=flac_picture.type, desc=flac_picture.desc,
+        data=flac_picture.data)
+
+
+def convert_toc_to_mcdi(flac_toc):
+    """Converts a FLAC formatted CDTOC into an MCDI ID3 tag."""
+    # docs https://forum.dbpoweramp.com/showthread.php?16705-FLAC-amp-Ogg-Vorbis-Storage-of-CDTOC
+    if not isinstance(flac_toc, (str, bytes)) and isinstance(flac_toc, (list, set)):
+        flac_toc = flac_toc[0]
+
+    # split the string/bytes on a '+' separator, parsing each entry as integers
+    toc = [int(i, 16) for i in flac_toc.split(b'+' if isinstance(flac_toc, bytes) else '+')]
+
+    # track count is a 32bit unsigned integer; each address is a 64bit unsigned integer
+    track_count, track_addresses = struct.pack('>I', toc[0]), list(map(lambda a: struct.pack('>Q', a), toc[1:]))
+
+    # flatten out all of the bytes for the various entries and produce one long byte stream
+    return MCDI(data=track_count + bytes([b for ba in track_addresses for b in ba]))

--- a/src/mutagentools/flac/fixtures/sample-flac-tags.json
+++ b/src/mutagentools/flac/fixtures/sample-flac-tags.json
@@ -1,0 +1,45 @@
+{
+  "accurateripdiscid": "028-0030bb28-03c552e0-8b0b7f1c-1",
+  "accurateripresult": "AccurateRip: Accurate (confidence 7)   [77542706]",
+  "album": "Popstar: Never Stop Never Stopping",
+  "albumartist": "The Lonely Island",
+  "album artist": "The Lonely Island",
+  "artist": [
+    "The Lonely Island",
+    "Adam Levine"
+  ],
+  "author": "The Lonely Island",
+  "cddb disc id": "8B0B7F1C",
+  "cdtoc": "1C+96+2D5C+30DE+5B58+7F78+AB96+D9FE+DDC8+101B6+12A96+14C97+17183+17324+19F19+1C986+1E1DD+1E7F1+20524+221BE+22674+23809+26B9F+27F2F+2B19E+2D23F+2FA58+31C6E+3355F+35F04",
+  "composer": [
+    "Al Hoffman",
+    "John Klenner",
+    "Can \"Stress\" Canatan",
+    "Andy Samberg",
+    "Jorma Taccone",
+    "Skiva Schaffer"
+  ],
+  "crc": "B66CF0EA",
+  "date": "2016",
+  "discnumber": "1",
+  "encoded by": "dBpoweramp Release 14.2",
+  "encoder": "FLAC 1.2.1",
+  "encoder settings": "-compression-level-5 -verify",
+  "genre": "Stage & Screen",
+  "length": "152826",
+  "mbid": "a56e6f46-f45b-4271-b389-904297463aaf",
+  "organization": "Republic",
+  "profile": "(default)",
+  "source": "CD (Lossless)",
+  "style": [
+    "Comedy",
+    "Soundtracks",
+    "Music Comedy",
+    "Teen Pop"
+  ],
+  "title": "I'm So Humble",
+  "totaldiscs": "1",
+  "totaltracks": "28",
+  "tracknumber": "1",
+  "year": "2016"
+}

--- a/src/mutagentools/flac/tests.py
+++ b/src/mutagentools/flac/tests.py
@@ -3,12 +3,37 @@
 
 from base64 import b64encode
 
-from mutagen.flac import FLAC
+from mutagen.flac import FLAC, Picture
+from mutagen.id3 import (
+    APIC, ID3, MCDI, TALB, TCOM, TCON, TDRC, TIT2, TLEN, TPE1, TPE2, TPOS, TPUB, TRCK, UFID
+)
 
 from mutagentools.flac import to_json_dict
+from mutagentools.flac.convert import (
+    convert_flac_to_id3,
+    convert_generic_to_txxx,
+    convert_encoder_to_txxx,
+    convert_encoded_by_to_txxx,
+    convert_encoder_settings_to_txxx,
+    convert_disc_number_to_tpos,
+    convert_track_number_to_trck,
+    convert_genre_to_tcon,
+    convert_length_to_tlen,
+    convert_mbid_to_ufid,
+    convert_album_to_talb,
+    convert_organization_to_tpub,
+    convert_albumartist_to_tpe2,
+    convert_artist_to_tpe1,
+    convert_date_to_tdrc,
+    convert_title_to_tit2,
+    convert_composer_to_tcom,
+    convert_picture_to_apic,
+    convert_toc_to_mcdi,
+)
 
+import json
 import os
-
+import struct
 import unittest
 
 from unittest import mock
@@ -76,3 +101,357 @@ class MainTestCase(unittest.TestCase):
         self.assertIsNotNone(result.get('pictures', None))
         self.assertTrue(isinstance(result.get('pictures'), list))
         self.assertEqual(1, len(result.get('pictures')))
+
+
+class FullConversionTestCase(unittest.TestCase):
+
+    def test_convert_flac_to_id3(self):
+        """Tests full conversion of a series of FLAC key-value pairs into an array of ID3 tags."""
+        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures/sample-flac-tags.json")) as f:
+            fixture = json.load(f)
+
+        flac_mock = mock.MagicMock()
+        flac_mock.tags = fixture
+
+        # create mock pictures
+        cover_front = Picture()
+        cover_front.type = 3
+        cover_front.desc = 'Cover Front'
+        cover_front.mime = 'image/jpeg'
+        cover_front.data = [0x00] * 8
+
+        cover_back = Picture()
+        cover_back.type = 4
+        cover_back.desc = 'Cover Back'
+        cover_back.mime = 'image/jpeg'
+        cover_back.data = [0x00] * 8
+
+        flac_mock.pictures = [cover_front, cover_back]
+
+        result = convert_flac_to_id3(flac_mock)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, list))
+
+        # form it into a single ID3 object
+        id3 = ID3()
+        for tag in result:
+            id3.add(tag)
+
+        # album artist/artist/composer
+        self.assertEqual(fixture.get('albumartist'), id3.get('TPE2'))
+        self.assertEqual(fixture.get('artist'), id3.get('TPE1'))
+        self.assertEqual(fixture.get('composer'), id3.get('TCOM'))
+
+        # album/disk id/date/genre/publisher org
+        self.assertEqual(fixture.get('album'), id3.get('TALB'))
+        self.assertEqual(['1/1'], id3.get('TPOS'))
+        self.assertEqual(fixture.get('date'), id3.get('TDRC'))
+        self.assertEqual([fixture.get('genre')] + list(fixture.get('style')), id3.get('TCON'))
+        self.assertEqual([fixture.get('organization')], id3.get('TPUB'))
+
+        # album toc and musicbrainz id
+        self.assertIsNotNone(id3.get('MCDI'))
+        self.assertEqual(28, struct.unpack('>I', id3.get('MCDI').data[0:4])[0])
+
+        self.assertEqual(fixture.get('mbid').encode('ascii'), id3.get('UFID:http://musicbrainz.org').data)
+
+        # track/track number/length
+        self.assertEqual(fixture.get('title'), id3.get('TIT2'))
+        self.assertEqual(['01/28'], id3.get('TRCK'))
+        self.assertEqual(['152826'], id3.get('TLEN'))
+
+        # make sure that CRC got dropped
+        self.assertIsNone(id3.get('TXXX:crc'))
+
+        # encoding tags
+        self.assertEqual(fixture.get('encoder'), id3.get('TXXX:original encoder'))
+        self.assertEqual(fixture.get('encoded by'), id3.get('TXXX:originally encoded by'))
+        self.assertEqual(fixture.get('encoder settings'), id3.get('TXXX:original encoder settings'))
+
+        # test that miscellaneous tags got brought in
+        self.assertEqual(fixture.get('source'), id3.get('TXXX:source'))
+        self.assertEqual(fixture.get('profile'), id3.get('TXXX:profile'))
+        self.assertEqual(fixture.get('cddb disc id'), id3.get('TXXX:cddb disc id'))
+        self.assertEqual(fixture.get('accurateripdiscid'), id3.get('TXXX:accurateripdiscid'))
+        self.assertEqual(fixture.get('accurateripresult'), id3.get('TXXX:accurateripresult'))
+
+        # test that there's only a fixed number of TXXX tags there
+        self.assertEqual(8, len(list(filter(lambda t: t.FrameID == "TXXX", id3.values()))))
+
+        # test that pictures work
+        apic_list = list(filter(lambda t: t.FrameID == 'APIC', id3.values()))
+        apic_front = list(filter(lambda p: p.type == 3, apic_list))[0]
+        apic_back = list(filter(lambda p: p.type == 4, apic_list))[0]
+        self.assertEqual(2, len(apic_list))
+        # test front picture
+        self.assertEqual(cover_front.type, apic_front.type)
+        self.assertEqual(cover_front.mime, apic_front.mime)
+        self.assertEqual(cover_front.desc, apic_front.desc)
+        self.assertEqual(bytes(cover_front.data), apic_front.data)
+        # test back picture
+        self.assertEqual(cover_back.type, apic_back.type)
+        self.assertEqual(cover_back.mime, apic_back.mime)
+        self.assertEqual(cover_back.desc, apic_back.desc)
+        self.assertEqual(bytes(cover_back.data), apic_back.data)
+
+    def test_convert_flac_to_id3_track(self):
+        """
+        Test that converting FLAC tags to ID3 tags for complicated tracknumber tags.
+
+        Sometimes we'll get a bullshit tracknumber tag which will be %d/%d which we will need to expand and resolve
+        properly into correct ID3 format.
+        """
+
+        flac_mock = mock.MagicMock()
+        flac_mock.tags = { 'tracknumber': '1/5' }
+
+        id3 = ID3()
+        list(map(lambda t: id3.add(t), convert_flac_to_id3(flac_mock)))
+
+        self.assertEqual(['01/05'], id3.get('TRCK'))
+
+    def test_convert_flac_to_id3_adds_tpos(self):
+        """Test that convert_flac_to_id3 adds TPOS if not present."""
+        flac_mock = mock.MagicMock()
+        flac_mock.tags = {}
+
+        id3 = ID3()
+        list(map(lambda t: id3.add(t), convert_flac_to_id3(flac_mock)))
+
+        self.assertEqual(['1/1'], id3.get('TPOS'))
+
+
+class IndividualConversionTestCase(unittest.TestCase):
+
+    def test_convert_generic_to_txxx(self):
+        """Test converting a generic FLAC Vorbis comment into a TXXX tag."""
+        key, value = "accurateripdiscid", "028-0030bb28-03c552e0-8b0b7f1c-1"
+
+        result = convert_generic_to_txxx(key, value)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(key, result.desc)
+        self.assertEqual([value], result.text)
+
+    def test_convert_encoder_to_txxx(self):
+        """Test converting an encoder tag to a TXXX tag."""
+        value = "FLAC 1.2.1"
+        result = convert_encoder_to_txxx(value)
+
+        self.assertIsNotNone(result)
+        self.assertEqual("original encoder", result.desc)
+        self.assertEqual([value], result.text)
+
+    def test_convert_encoded_by_to_txxx(self):
+        """Test converting an encoded by tag to a TXXX tag."""
+        value = "dBpoweramp Release 14.2"
+        result = convert_encoded_by_to_txxx(value)
+
+        self.assertIsNotNone(result)
+        self.assertEqual("originally encoded by", result.desc)
+        self.assertEqual([value], result.text)
+
+    def test_convert_encoder_settings_to_txxx(self):
+        """Test converting an encoder settings tag to a TXXX tag."""
+        value = "-compression-level-5 -verify"
+        result = convert_encoder_settings_to_txxx(value)
+
+        self.assertIsNotNone(result)
+        self.assertEqual("original encoder settings", result.desc)
+        self.assertEqual([value], result.text)
+
+    def test_convert_disc_number_to_tpos(self):
+        """Test converting a FLAC disc number to TPOS."""
+        # first test with only a disc number
+        disc_number = "2"
+        result = convert_disc_number_to_tpos(disc_number)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TPOS))
+        self.assertEqual(["2"], result.text)
+
+        # test with disc number and total discs
+        disc_number = "2"
+        total_discs = "5"
+        result = convert_disc_number_to_tpos(disc_number, total_discs)
+
+        self.assertEqual(["2/5"], result.text)
+
+    def test_convert_tracknumber_to_trck(self):
+        """Test converting a FLAC track number to TRCK."""
+        # first test with only a track number
+        track_number = "1"
+        result = convert_track_number_to_trck(track_number)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TRCK))
+        self.assertEqual(["01"], result.text)
+
+        # next, test with both track number and track count
+        track_number = "3"
+        total_tracks = "9"
+        result = convert_track_number_to_trck(track_number, total_tracks)
+
+        self.assertEqual(["03/09"], result.text)
+
+        # next, futz around with arrays
+        result = convert_track_number_to_trck([1], [13])
+        self.assertEqual(["01/13"], result.text)
+
+
+    def test_convert_genre_to_tcon(self):
+        """Test converting a FLAC genre tag to a TCON ID3 tag."""
+        fixture = "Genre"
+        result = convert_genre_to_tcon(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TCON))
+        self.assertEqual([fixture], result.text)
+
+        fixture = ["Genre 1", "Genre 2"]
+        fixture_s = ["Style 1", "Style 2"]
+        result = convert_genre_to_tcon(fixture, fixture_s)
+
+        self.assertEqual(["Genre 1", "Genre 2", "Style 1", "Style 2"], result.text)
+
+    def test_convert_length_to_tlen(self):
+        """Test converting a FLAC length tag to a TLEN ID3 tag."""
+        # test with single instance
+        fixture = 12345
+        result = convert_length_to_tlen(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TLEN))
+        self.assertEqual([str(fixture)], result.text)
+
+        # test with an array
+        fixture = ['12345']
+        result = convert_length_to_tlen(fixture)
+
+        self.assertEqual(fixture, result.text)
+
+
+    def test_convert_mbid_to_ufid(self):
+        """Test converting a MusicBrainz ID to an ID3 UFID tag."""
+        fixture = "a56e6f46-f45b-4271-b389-904297463aaf"
+        result = convert_mbid_to_ufid(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, UFID))
+        self.assertEqual('http://musicbrainz.org', result.owner)
+        self.assertEqual(bytes(fixture, 'ascii'), result.data)
+
+    def test_convert_album_to_talb(self):
+        """Test converting a FLAC album to a TALB ID3 tag."""
+        fixture = "Album"
+        result = convert_album_to_talb(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TALB))
+        self.assertEqual([fixture], result.text)
+
+    def test_convert_organization_to_tpub(self):
+        """Test converting a FLAC organization to a TPUB ID3 tag."""
+        fixture = "Organization"
+        result = convert_organization_to_tpub(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TPUB))
+        self.assertEqual([fixture], result.text)
+
+    def test_convert_albumartist_to_tpe2(self):
+        """Test converting a FLAC album artist tag into a TPE2 ID3 tag."""
+        fixture = "Album Artist"
+        result = convert_albumartist_to_tpe2(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TPE2))
+        self.assertEqual([fixture], result.text)
+
+    def test_convert_artist_to_tpe1(self):
+        """Test converting a FLAC artist tag into a TPE1 ID3 tag."""
+        fixture = "Artist 1"
+        result = convert_artist_to_tpe1(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TPE1))
+        self.assertEqual(result.text, [fixture])
+
+        # test multiple artists
+        fixture = ["Artist 1", "Artist 2"]
+        result = convert_artist_to_tpe1(fixture)
+
+        self.assertEqual(result.text, fixture)
+
+    def test_convert_date_to_tdrc(self):
+        """Test converting a FLAC date tag into a TDRC ID3 tag."""
+        fixture = "2017"
+        result = convert_date_to_tdrc(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TDRC))
+        # mutagen renders this value as an ID3TimeStamp, so map it to a string
+        self.assertEqual(list(map(lambda i: str(i), result.text)), [fixture])
+
+    def test_convert_title_to_tit2(self):
+        """Test converting a FLAC title tag into a TIT2 ID3 tag."""
+        fixture = "Title"
+        result = convert_title_to_tit2(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TIT2))
+        self.assertEqual(result.text, [fixture])
+
+    def test_convert_composer_to_tcom(self):
+        """Tests converting a FLAC composer tag into a TCOM ID3 tag."""
+        # test single string
+        fixture = "Composer 1"
+        result = convert_composer_to_tcom(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, TCOM))
+        self.assertEqual(result.text, [fixture])
+
+        # test an array
+        fixture = ["Composer 1", "Composer 2"]
+        result = convert_composer_to_tcom(fixture)
+
+        self.assertEqual(result.text, fixture)
+
+    def test_convert_picture_to_apic(self):
+        """Tests converting a FLAC picture to an APIC ID3 tag."""
+        fixture = Picture()
+        fixture.desc = "OMG DESC"
+        fixture.data = bytes([0x00] * 8)
+        fixture.mime = "image/jpeg"
+        fixture.type = 3
+
+        result = convert_picture_to_apic(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, APIC))
+
+        # test properties
+        self.assertEqual(fixture.desc, result.desc)
+        self.assertEqual(fixture.data, result.data)
+        self.assertEqual(fixture.mime, result.mime)
+        self.assertEqual(fixture.type, result.type)
+
+    def test_convert_toc_to_mcdi(self):
+        """Tests converting a FLAC CDTOC to an MCDI ID3 tag."""
+        fixture = b"1C+96+2D5C+30DE+5B58+7F78+AB96+D9FE+DDC8+101B6+12A96+14C97+17183+17324+19F19+1C986+1E1DD+1E7F1+20524+221BE+22674+23809+26B9F+27F2F+2B19E+2D23F+2FA58+31C6E+3355F+35F04"
+        fixture_len = len(fixture.split(b"+"))
+
+        result = convert_toc_to_mcdi(fixture)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, MCDI))
+
+        # test length
+        self.assertEqual(4 + ((fixture_len - 1) * 8), len(result.data))
+
+        # test track count
+        self.assertEqual(28, struct.unpack('>I', result.data[0:4])[0])
+        # test that first track begins at sector 150
+        self.assertEqual(150, struct.unpack('>Q', result.data[4:12])[0])

--- a/src/mutagentools/utils/__init__.py
+++ b/src/mutagentools/utils/__init__.py
@@ -4,5 +4,5 @@
 def fold_text_keys(dct):
     """Collapses dictionary key entries which are lists of single strings."""
     for key, value in dct.items():
-        if isinstance(value, (list, set)) and len(value) == 1 and isinstance(value[0], str):
+        if isinstance(value, (list, set)) and len(value) == 1 and isinstance(value[0], (str, int)):
             dct[key] = value[0]


### PR DESCRIPTION
#### Tags to Convert

##### Track Tags

 - [x] `title` :arrow_right: `TIT2`
 - [x] `tracknumber`/`totaltracks` :arrow_right:  `TRCK`
 - [x] `length` :arrow_right: `TLEN`

##### Album Tags

- [x] `album` :arrow_right: `TALB`
- [x] `discnumber`/`totaldisks` :arrow_right: `TPOS` 
- [x] `genre` :arrow_right: `TCON`
- [x] `date` :arrow_right: `TDRC`
- [x] `cdtoc` :arrow_right: `MCDI`
- [x] `mbid` :arrow_right: `UFID:http://musicbrainz.org`
- [x] `organization` :arrow_right: `TPUB`

##### Artist Tags

 - [x] `artist` :arrow_right: `TPE1`
 - [x] `albumartist` :arrow_right: `TPE2`
 - [x] `composer` :arrow_right: `TCOM`

##### Pictures Tags

  - [x] `pictures` :arrow_right: `APIC`

##### Miscellany

- [x] drop `crc`; its usefulness is dubious at best; it's a CRC of the original FLAC audio.
- [x] `encoder` :arrow_right: `TXXX:original encoder`
- [x] `encoded by` :arrow_right: `TXXX:originally encoded by`
- [x] `encoder settings` :arrow_right: `TXXX:original encoder settings`

##### Default Handled Tags

- [x] `accurateripresult` :arrow_right: `TXXX`
- [x] `accurateripdiscid` :arrow_right: `TXXX`
- [x] `source` :arrow_right: `TXXX`
- [x] `cddb disc id` :arrow_right: `TXXX`