### PR TITLE
Special Treatment of TXXX Tags in id3json.

### DIFF
--- a/src/mutagentools/id3/__init__.py
+++ b/src/mutagentools/id3/__init__.py
@@ -6,7 +6,7 @@ from base64 import b64encode
 from itertools import accumulate
 
 from mutagen.id3 import (
-    NumericTextFrame, TextFrame, UrlFrame, BinaryFrame, APIC,
+    NumericTextFrame, TextFrame, UrlFrame, BinaryFrame, APIC, TXXX
 )
 
 from mutagen.id3._specs import (
@@ -39,7 +39,10 @@ def to_json_dict(id3, include_pics=False, flatten=False):
         frame_name = first_frame.FrameID
         values = result.get(frame_name, [])
 
-        if isinstance(first_frame, NumericTextFrame):
+        if isinstance(first_frame, TXXX):
+            values = values if values else {}
+            values.update({ f.desc: f.text for f in frames })
+        elif isinstance(first_frame, NumericTextFrame):
             # integer-representable text frame
             values += [int(text) for frame in id3.getall(key) for text in frame.text]
         elif isinstance(first_frame, TextFrame):
@@ -83,6 +86,7 @@ def to_json_dict(id3, include_pics=False, flatten=False):
     # if we're supposed to flatten, do it now
     if flatten:
         fold_text_keys(result)
+        fold_text_keys(result.get('TXXX')) if 'TXXX' in result.keys() else None
 
     return result
 

--- a/src/mutagentools/id3/tests.py
+++ b/src/mutagentools/id3/tests.py
@@ -4,7 +4,7 @@
 from base64 import b64encode
 
 from mutagen.id3 import (
-    APIC, ID3, Encoding, PictureType, PRIV, TIT2, TPE2, WCOM, WCOP, TBPM, TYER, MCDI
+    APIC, ID3, Encoding, PictureType, PRIV, TIT2, TPE2, WCOM, WCOP, TBPM, TYER, TXXX, MCDI
 )
 
 from mutagentools.id3 import (
@@ -56,6 +56,8 @@ class MainTestCase(unittest.TestCase):
         picture_binary = bytes([0x00] * 32)
 
         fixture = ID3()
+        # add TXXX key-value pair
+        fixture.add(TXXX(encoding=Encoding.UTF8, desc="key", text="value"))
         # test that single numeric text entries get represented
         fixture.add(TBPM(encoding=Encoding.UTF8, text="140"))
         # test that multiple numeric text entries get represented
@@ -149,6 +151,8 @@ class MainTestCase(unittest.TestCase):
             'type': 4,
             'type_friendly': "COVER_BACK",
         }, result.get('APIC'))
+
+        self.assertEqual({'key': ['value']}, result.get('TXXX'))
 
     def test_to_json_dict_flat(self):
         """Tests the flat json dict."""


### PR DESCRIPTION
`TXXX` tags are key-value pairs, so they should be treated differently and expanded into dictionaries.